### PR TITLE
Allow pending operations to be cancelled from front-end

### DIFF
--- a/frontend/app/scripts/resources/operation_resource.coffee
+++ b/frontend/app/scripts/resources/operation_resource.coffee
@@ -61,7 +61,8 @@ app.factory "Operation", ($filter, $injector, RepositoryCheckout) ->
       @subject.endedTime() - @subject?.startedAt
 
   Operation::cancelable = ->
-    @status() == 'running'
+    status = @status();
+    return status == 'running' || status == 'pending'
 
   Operation::status = ->
     if @subject.canceledAt


### PR DESCRIPTION
This change allows cancelling pending operations, which could otherwise only be cancelled when they actually reached the running state. When no VM could be acquired or for other reasons the operation didn't start, there would be no sound way of cancelling those seemingly stuck tasks from the front-end.